### PR TITLE
Diverse improvements

### DIFF
--- a/kvarko-cli/src/main.rs
+++ b/kvarko-cli/src/main.rs
@@ -22,9 +22,7 @@ fn perft(fen: &str, depth: usize) -> Result<usize, FenError> {
         }
     
         if depth == 1 {
-            moves.clear();
-            movement::list_moves_in(state.position(), moves);
-            return moves.len();
+            return movement::count_moves(state.position()).0;
         }
     
         let mut sum = 0;

--- a/kvarko-model/tests/perft.rs
+++ b/kvarko-model/tests/perft.rs
@@ -1,5 +1,5 @@
 use kvarko_model::hash::IdHasher;
-use kvarko_model::movement::list_moves;
+use kvarko_model::movement::{count_moves, list_moves};
 use kvarko_model::state::State;
 
 fn perft_rec(state: &mut State<IdHasher>, depth: usize) -> usize {
@@ -8,7 +8,7 @@ fn perft_rec(state: &mut State<IdHasher>, depth: usize) -> usize {
     }
 
     if depth == 1 {
-        return list_moves(state.position()).0.len();
+        return count_moves(state.position()).0;
     }
 
     let mut sum = 0;


### PR DESCRIPTION
Made perft more efficient by using count_moves at the lowest level.
Fixed doubled pawn penalty not being correctly applied and added a test case for that.
Improved code style of th quiescence tree search evaluator by using a reference to self in evaluate_rec instead of so many parameters.